### PR TITLE
Fix name of `X_VCPKG_NUGET_ID_PREFIX` environment variable

### DIFF
--- a/vcpkg/users/config-environment.md
+++ b/vcpkg/users/config-environment.md
@@ -96,12 +96,12 @@ This environment variable changes the metadata of produced NuGet packages. See [
 
 This environment variable allows using NuGet's cache for every nuget-based binary source. See [Binary Caching](../reference/binarycaching.md#nuget) for more details.
 
-## X_VCPKG_NUGET_PREFIX
+## X_VCPKG_NUGET_ID_PREFIX
 
 Adds a prefix to the name of all the binary packages pushed or restored from
 [NuGet binary caches](../reference/binarycaching.md#nuget).
 
-For example, when `X_VCPKG_NUGET_PREFIX` is set to `vcpkg_demo-` the
+For example, when `X_VCPKG_NUGET_ID_PREFIX` is set to `vcpkg_demo-` the
 `zlib_x64-windows.1.2.13-vcpkg8918746ce8b60474e5ebe68e53355fa70eb05119be913a1d1dc0b930b3b7b6e8.nupkg`
 binary package becomes
 `vcpkg_demo-zlib_x64-windows.1.2.13-vcpkg8918746ce8b60474e5ebe68e53355fa70eb05119be913a1d1dc0b930b3b7b6e8.nupkg`.


### PR DESCRIPTION
The name has always included `ID_` since its introduction in microsoft/vcpkg-tool#40.