### PR TITLE
Demote x64-osx to community status.

### DIFF
--- a/vcpkg/concepts/supported-hosts.md
+++ b/vcpkg/concepts/supported-hosts.md
@@ -3,7 +3,7 @@ title:  Supported hosts
 description: This article describes the platforms on which vcpkg is supported.
 author: bion
 ms.author: bion
-ms.date: 10/17/2024
+ms.date: 09/24/2025
 ms.topic: concept-article
 ---
 
@@ -54,47 +54,49 @@ The fully supported, tested platforms are:
 
 ### Windows
 
-* The latest Windows / Windows Server release. These are Windows 11 and Windows Server 2022 as of this writing.
-* The latest Visual Studio update, Visual Studio 2022 version 17.11 as of this writing.
+* The latest Windows / Windows Server release. These are Windows 11 and Windows Server 2025 as of this writing.
+* The latest Visual Studio update, Visual Studio 2022 version 17.14 as of this writing.
 
-### macOS
+### macOS (arm64 / "Apple Silicon")
 
 macOS is intended to track the latest version of macOS and contemporary version of Xcode Command Line tools. However,
-updating macOS machines is a manual process, and macOS frequently changes things in ways that break vcpkg's testing. As of this writing, we are using:
+updating macOS machines is a manual process, and macOS frequently changes things in ways that break vcpkg's testing.
+As of this writing, we are using:
 
-* macOS 14.5
-* XCode Command Line Tools 15.3
+* macOS 15.6.1
+* XCode Command Line Tools 16.4
 
 ### Linux
 
-* The latest LTS release of Ubuntu, currently 22.04.
+* The latest LTS release of Ubuntu, currently 24.04.
 
 ### Android
 
-* Linux 64-bit Android NDK version r26d
+* Linux 64-bit Android NDK version r28c
 
 ## Full support, expected
 
 ### Windows
 
-* Windows 8.1 / Windows Server 2016 and later
-* Visual Studio 2015 and later
+* Windows 10 / Windows Server 2019 and later
+* Visual Studio 2017 and later
 
 ### macOS
 
-* The latest version of macOS, minus 2 major versions. For example, the current version of macOS is macOS 15 Sequoia,
-so we expect vcpkg to work as far back as macOS 13 Ventura. This is intended to track with Apple's own support for
+* The latest version of macOS, minus 2 major versions. For example, the current version of macOS is macOS 26 Tahoe,
+so we expect vcpkg to work as far back as macOS 14 Sonoma. This is intended to track with Apple's own support for
 macOS.
 * Contemporary versions of the Xcode Command Line Tools for a given release of macOS.
+* macOS x64
 
 ### Linux
 
 We intend to support AMD64 builds of glibc-based Linuxes still in support from their distribution vendor released within
 the last 5 years. Examples:
 
-* Ubuntu 24.04, 22.04, and 20.04 are in support from Canonical and released within the last 5 years, so they
-are expected to work. Ubuntu 18.04 is still in support from Canonical but was released more than 5 years ago, so
-we no longer consider it fully supported. 20.10 is newer than 20.04, but we do not consider it fully supported because
+* Ubuntu 24.04, and 22.04 are in support from Canonical and released within the last 5 years, so they
+are expected to work. Ubuntu 20.04 is still in ESM support from Canonical but was released more than 5 years ago, so
+we no longer consider it fully supported. 23.10 is newer than 22.04, but we do not consider it fully supported because
 it is no longer in support from Canonical.
 * Red Hat Enterprise Linux 9 is fully supported.
 * CentOS and Red Hat Enterprise Linux 8 left support from Red Hat on May 31, 2024, and was released more than 5 years
@@ -102,18 +104,18 @@ ago, and is thus no longer supported.
 * CentOS and RHEL 7 are out of support from Red Hat, and are not expected to work as they were released more than 5
 years ago. The Oracle Linux fork now supported by Oracle is still in support from Oracle, but still not expected to
 work as it was released more than 5 years ago.
-* Fedora 40 and 39 are fully supported, but 38 is no longer supported by Fedora.
-* Debian 12 "Bookworm", and 11 "Bullseye" are all supported by Debian and released in the last 5 years.
+* Fedora 42 and 41 are fully supported, but 40 is no longer supported by Fedora.
+* Debian 13 "Trixie", 12 "Bookworm", and 11 "Bullseye" are all supported by Debian and released in the last 5 years.
 Debian 10 "Buster" left support from the Debian project in July 2024 and is thus not supported by vcpkg.
 
 We also assume that users' build systems will match the version of Linux they are using, and take care to ensure
 components like our manifest mode CMake integration will work with the versions of these dependencies that come with
 one of the above distros. As of this writing, those dependency versions and the associated distro(s) are:
 
-* GCC 9.4.0 (Ubuntu 20.04)
-* CMake 3.16.3 (Ubuntu 20.04)
+* GCC 10.2.1 (Debian 11)
+* CMake 3.18.4 (Debian 11)
 * Ninja 1.10.0 (All)
-* Curl 7.68 (Ubuntu 20.04)
+* Curl 7.74.0 (Debian 11)
 * zip 3.0 (All)
 * unzip 6.0 (All)
 
@@ -171,4 +173,4 @@ or vcpkg will fail to extract its binary cache.
 of support tooling like CMake.
 * Visual Studio 2013 or earlier.
 * Windows Vista or earlier.
-* macOS or Linux hosts older than those in the *Fully supported* categories.
+* macOS or Linux hosts older than those in one of the other above categories.


### PR DESCRIPTION
Because the x64 mac hardware we have can no longer have current versions of macOS installed, we will be demoting it to community status soon.